### PR TITLE
[BelongsToMany] Use proper foreign key in count()

### DIFF
--- a/src/LucidMongo/Relations/BelongsToMany.js
+++ b/src/LucidMongo/Relations/BelongsToMany.js
@@ -560,7 +560,7 @@ class BelongsToMany extends BaseRelation {
   async count (...args) {
     this._decorateQuery()
     const pivotInstances = await this.pivotQuery().fetch()
-    const foreignKeyValues = _.map(pivotInstances.rows, this.foreignKey)
+    const foreignKeyValues = _.map(pivotInstances.rows, this.relatedForeignKey)
     return this.relatedQuery.whereIn(this.relatedPrimaryKey, foreignKeyValues).count(...args)
   }
 


### PR DESCRIPTION
Thanks to mquery debug logs, I found out that the count operation in BelongsToMany relationships was using the foreign key of the originating model (and not the foreign key of the related model).