### PR TITLE
Fixed TypeError setRelated of null in first method

### DIFF
--- a/src/LucidMongo/Relations/BelongsToMany.js
+++ b/src/LucidMongo/Relations/BelongsToMany.js
@@ -547,6 +547,11 @@ class BelongsToMany extends BaseRelation {
     const pivotInstances = await this.pivotQuery().fetch()
     const foreignKeyValues = _.map(pivotInstances.rows, this.relatedForeignKey)
     const related = await this.relatedQuery.whereIn(this.relatedPrimaryKey, foreignKeyValues).first()
+    
+    if (!related) {
+      return null
+    }
+    
     const pivot = _.find(pivotInstances.rows, pivot => String(pivot[this.relatedForeignKey]) === String(related[this.relatedPrimaryKey]))
     related.setRelated('pivot', pivot)
     return related

--- a/src/LucidMongo/Relations/BelongsToMany.js
+++ b/src/LucidMongo/Relations/BelongsToMany.js
@@ -547,11 +547,11 @@ class BelongsToMany extends BaseRelation {
     const pivotInstances = await this.pivotQuery().fetch()
     const foreignKeyValues = _.map(pivotInstances.rows, this.relatedForeignKey)
     const related = await this.relatedQuery.whereIn(this.relatedPrimaryKey, foreignKeyValues).first()
-    
+
     if (!related) {
       return null
     }
-    
+
     const pivot = _.find(pivotInstances.rows, pivot => String(pivot[this.relatedForeignKey]) === String(related[this.relatedPrimaryKey]))
     related.setRelated('pivot', pivot)
     return related

--- a/test/unit/lucid-belongs-to-many.spec.js
+++ b/test/unit/lucid-belongs-to-many.spec.js
@@ -295,6 +295,28 @@ test.group('Relations | Belongs To Many', (group) => {
     assert.equal(post.title, 'Adonis 101')
   })
 
+  test('fetch related rows to inexistant relation', async (assert) => {
+    class Post extends Model {
+    }
+
+    class User extends Model {
+      posts () {
+        return this.belongsToMany(Post).withPivot('is_published')
+      }
+    }
+
+    User._bootIfNotBooted()
+    Post._bootIfNotBooted()
+
+    const userResult = await ioc.use('Database').collection('users').insert({ username: 'virk' })
+    const postResult = await ioc.use('Database').collection('posts').insert([{ title: 'Adonis 101' }, { title: 'Lucid 101' }])
+    await ioc.use('Database').collection('post_user').insert({ post_id: postResult.insertedIds[0], user_id: 42 })
+
+    const user = await User.find(userResult.insertedIds[0])
+    const post = await user.posts().first()
+    assert.equal(post, null)
+  })
+
   test('add constraints on pivot collection', async (assert) => {
     class Post extends Model {
     }


### PR DESCRIPTION
I had this error when I tried to fetch the first relation through a BelongsToMany relationship with no result to return. My fix consists into returning null (if no result found) before trying to link the instances.

```
TypeError: Cannot read property 'setRelated' of null
  at Proxy.first (/home/richie/dev/pickaw/node_modules/lucid-mongo/src/LucidMongo/Relations/BelongsToMany.js:556:13)
```